### PR TITLE
DjangoCon US 2022 is live

### DIFF
--- a/_posts/2022-05-10-djangoconus-2022-live.md
+++ b/_posts/2022-05-10-djangoconus-2022-live.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title:  "DjangoCon US 2022 is live!"
+date: 2022-05-10 12:30:00
+categories: ""
+author_name : DEFNA
+author_url : /about
+author_avatar: defna
+show_avatar : true
+read_time : ""
+feature_image: 2016-07-20
+show_related_posts: false
+permalink: /announcements/2022/5/10/djangoconus-2022-live/
+---
+
+We are very excited to announce that the website for DjangoCon US 2022 is [live](https://2022.djangocon.us)! 
+
+The first in-person DjangoCon US conference since 2019 will be from Sunday, October 16th, through Friday, October 21st, 2022.
+
+- October 16: Tutorials ($195 per tutorial)
+- October 17, 18, &amp; 19: Talks
+- October 20 &amp; 21: Sprints
+
+This year we will be returning to the [Marriott of Mission Valley](https://2022.djangocon.us/venue/) in San Diego, CA. Tickets will be on sale soon, and our [hotel block is already open](https://www.marriott.com/events/start.mi?id=1642551494496&key=GRP).
+
+We are accepting opportunity grant applications through end of day June 10th, 2022 [AoE](https://time.is/compare/0000_10_June_2022_in_Anywhere_on_Earth).
+
+Now is the time to start getting your submissions for talks and tutorials ready because our [call for proposals (CFP)](https://2022.djangocon.us/speaking/) deadline is the end of day on June 10th, 2022 [AoE](https://time.is/compare/0000_10_June_2022_in_Anywhere_on_Earth). As long as it’s still June 10th somewhere in the world, you can submit your proposal or opportunity grant application! 
+
+We invite you to submit your proposal no matter your background or experience level with Django. Proposals can be from a wide range of topics; non-Django and community topics are welcome. You can look at our [talk schedule](https://2021.djangocon.us/talks/) from last year for reference.
+
+We look forward to seeing all of the prospective talks and tutorials!
+
+[Keep in touch](https://twitter.com/djangocon) for more announcements along the way!
+
+DjangoCon US Organizers ⛵️


### PR DESCRIPTION
Post announcing DjangoCon US 2022
Following doc: https://docs.google.com/document/d/1MxJbKC2o9rsQP2jRSt5QDGgtjGI59C-zN0XBzGBoNE0/edit