### PR TITLE
CFP - trim down the details required

### DIFF
--- a/_posts/2023-06-17-call-for-venue-proposal-2024.md
+++ b/_posts/2023-06-17-call-for-venue-proposal-2024.md
@@ -17,7 +17,7 @@ We’re in the middle of planning DjangoCon US 2023, so it’s time to think abo
 
 So you want your city to host DjangoCon US? Hurrah! We’re delighted by your interest. Here’s what you need to know, and what we need to know, to consider your proposal.
 
-For 2024, we are looking at moving the conference to dates in the middle of October, but we are amenable to other dates in Q3.
+For 2024, we are looking at conference dates in the middle of October, but we are amenable to other dates in Q3.
 
 We need some information about your city, about the venue, the hotel, and travel. Your proposal doesn’t have to be super-fancy, just informative. The proposal should include the following:
 
@@ -29,32 +29,23 @@ We need some information about your city, about the venue, the hotel, and travel
 	* Location
 	* Transportation options (how do people get there from the airport?)
 	* Attendance capacity
-	* Layout of function space:
+	* Assurance that the venue can provide the following spaces (A floorplan with explanation of what will go where would be great.):
 		* Keynote room (also Sessions Track A) to accommodate up to 450 people, classroom style (tables with chairs)
 		* Room for Sessions Track B to accommodate up to 200 people, classroom style (tables with chairs)
 		* Space for sponsors to set up exhibit booths/tables; at least 12, and up to 16, sponsors with either 6’ tables or 10’ x 10’ booth spaces. If more sponsor booth space is available, that's a plus.
 		* Green room for speakers to prepare (generally a room that will seat 25 for a workshop is the right size)
-		* Location of registration tables
-		* Location of meals and breaks with sufficient seating and tables. If serving and/or seating areas cannot accommodate 450 people at once, indicate the room capacity and timing to move 450 people through.
-		* Location of supplemental beverage stations for daylong service.
+		* Space for registration tables
+		* Room for meals and breaks with sufficient seating and tables. If serving and/or seating areas cannot accommodate 450 people at once, indicate the room capacity and time required to move 450 people through.
+		* Space for supplemental beverage stations for daylong service.
 		* Secure overnight storage for vendor booth supplies and conference registration desk items.
 
-	* Catering:
-		* Tutorials day—100 people: Breakfast, morning break, lunch, afternoon break, and all day beverage service. (All day beverage service includes water stations, coffee, assorted black and herbal teas, and a variety of soft drinks.)
-		* Main conference, 3 days—450 people per day: Breakfast, morning break, lunch, afternoon break, and all day beverage service. (All day beverage service includes water stations, coffee, assorted black and herbal teas, and a variety of soft drinks.)
-		* Sprints, 2 days—75 people each day: Breakfast, morning break, lunch, afternoon break, and all day beverage service. (All day beverage service includes water stations, coffee, assorted black and herbal teas, and a variety of soft drinks.)
+	* Explanation of catering options available at the venue that can cover:
+		* 450 people per day: Breakfast, morning break, lunch, afternoon break, and all day beverage service.
 		* Catering must have options for celiacs, vegetarians, and vegans of equal quality and variety as main menu. Estimate 15% vegetarian, 5% vegan, and 5-10% gluten-free (some of which may overlap with the other two groups).
-
-	* Costs for:
-		* Function space
-		* Catering
-		* Audio-visual services
-		* Any other fees or costs the venue requires.
+		* The ability to serve a meal to 350—450 people in a 90 minute window.
 
 	* A good conference venue is/has the following:
 		* Easy to reach from the airport and the conference hotel
-		* Free parking if a car is required for access
-		* The ability to serve lunch to 350—450 people in a 90 minute window.
 		* Most venues require use of their in-house catering service. If the venue does not offer catering services, check whether the venue restricts catering access to an approved vendor list, and what, if any, requirements they have for outside catering vendors.
 		* Adjoins or within walking distance to a suitable hotel which can accommodate 350-450 attendees
 		* Excellent Internet connectivity
@@ -70,15 +61,14 @@ We need some information about your city, about the venue, the hotel, and travel
 	* Location
 	* Transportation options (how do people get there from the hotel?)
 	* Attendance capacity
-	* Cost of function space, catering, and audio-visual services. Sprints are often hosted by local companies as sponsorship of the event, which is preferable, as it saves the cost of renting a venue.
+	* Information on local companies that might host the sprints at no cost.
 	* A good sprint venue is/has the following:
 		* Easy to reach from the conference hotel
-		* Free parking if a car is required for access
 		* A room to hold 50-75 people, with work tables, chairs, power, and internet connectivity
-		* See catering requirements above. Eating tables should be separate from work tables if at all possible.
+		* Eating tables should be separate from work tables if at all possible.
 		* Excellent Internet connectivity.
 
-4. Hotel. The ideal hotel is adjacent to the conference venue, or a very short walk away. For the hotel, we need:
+4. Hotel. The ideal hotel is adjacent to the conference venue, or a very short walk away. For the hotel. You can reach out to the event sales contact at the hotel to help gather the information we need:
 
 	* Name
 	* Location
@@ -94,9 +84,8 @@ We need some information about your city, about the venue, the hotel, and travel
 	  * Thursday Sprints - 30
 	  * Friday Sprints - 15
 
-	* The block should include the guaranteed ability to add 20% more rooms for any given night if needed without moving to an overflow hotel.
 	* Concessions policy (comp room nights per actualized room nights)
-	* A sample contract showing the terms of booking the block of rooms. Again, do not sign any contracts. DEFNA will handle the business side of things. We just need to see the terms the hotel proposes for the group block.
+	* A sample contract showing the terms of booking the block of rooms. Do not sign any contracts. DEFNA will handle the business side of things. We just need to see the terms the hotel proposes for the group block.
 
 5. Provide estimates on costs associated with flights, accommodation, meals, ground transportation, etc. for an overview of the total cost for attendees.
 

--- a/_posts/2023-06-17-call-for-venue-proposal-2024.md
+++ b/_posts/2023-06-17-call-for-venue-proposal-2024.md
@@ -61,7 +61,7 @@ We need some information about your city, about the venue, the hotel, and travel
 	* Location
 	* Transportation options (how do people get there from the hotel?)
 	* Attendance capacity
-	* Information on local companies that might host the sprints at no cost.
+	* Information on local companies that might be willing to host the sprints at no cost.
 	* A good sprint venue is/has the following:
 		* Easy to reach from the conference hotel
 		* A room to hold 50-75 people, with work tables, chairs, power, and internet connectivity

--- a/_posts/2023-06-17-call-for-venue-proposal-2024.md
+++ b/_posts/2023-06-17-call-for-venue-proposal-2024.md
@@ -40,7 +40,7 @@ We need some information about your city, about the venue, the hotel, and travel
 		* Secure overnight storage for vendor booth supplies and conference registration desk items.
 
 	* Explanation of catering options available at the venue that can cover:
-		* 450 people per day: Breakfast, morning break, lunch, afternoon break, and all day beverage service.
+		* 450 people per day during the main conference: Breakfast, morning break, lunch, afternoon break, and all day beverage service.
 		* Catering must have options for celiacs, vegetarians, and vegans of equal quality and variety as main menu. Estimate 15% vegetarian, 5% vegan, and 5-10% gluten-free (some of which may overlap with the other two groups).
 		* The ability to serve a meal to 350—450 people in a 90 minute window.
 

--- a/_posts/2023-06-17-call-for-venue-proposal-2024.md
+++ b/_posts/2023-06-17-call-for-venue-proposal-2024.md
@@ -29,7 +29,7 @@ We need some information about your city, about the venue, the hotel, and travel
 	* Location
 	* Transportation options (how do people get there from the airport?)
 	* Attendance capacity
-	* Assurance that the venue can provide the following spaces (A floorplan with explanation of what will go where would be great.):
+	* Assurance that the venue can provide the following spaces (A floorplan with a rough explanation of what will go where would be great.):
 		* Keynote room (also Sessions Track A) to accommodate up to 450 people, classroom style (tables with chairs)
 		* Room for Sessions Track B to accommodate up to 200 people, classroom style (tables with chairs)
 		* Space for sponsors to set up exhibit booths/tables; at least 12, and up to 16, sponsors with either 6’ tables or 10’ x 10’ booth spaces. If more sponsor booth space is available, that's a plus.


### PR DESCRIPTION
My suggested edits to simplify the CFP requirements. Big thing is removing cost estimates and reducing the detail on catering. If the catering can support the main conference days, the rest will work out.

There's no way to get a good A/V quote for a CFP, I think.