### PR TITLE
Add timestamps to the URLs for the latest board updates.

### DIFF
--- a/_posts/2023-02-02-board-updates.md
+++ b/_posts/2023-02-02-board-updates.md
@@ -10,6 +10,7 @@ read_time: ""
 show_avatar: true
 show_related_posts: false
 title: "Board Member Update for 2023"
+permalink: /announcements/2023/02/17/board-updates/
 ---
 
 ## Outgoing Directors

--- a/_posts/2023-07-24-board-updates.md
+++ b/_posts/2023-07-24-board-updates.md
@@ -10,6 +10,7 @@ read_time: ""
 show_avatar: true
 show_related_posts: false
 title: "Board Member Update for July 2023"
+permalink: /announcements/2023/07/24/board-updates/
 ---
 
 We have a new board member as of July 2023!


### PR DESCRIPTION
This will break any existing links to that page.